### PR TITLE
#12 POST /things should not allow a TD with id

### DIFF
--- a/src/api-reference/things/things.service.ts
+++ b/src/api-reference/things/things.service.ts
@@ -4,6 +4,7 @@ import { Injectable } from '@nestjs/common';
 import { generate as generatePatch, apply as mergePatch } from 'json-merge-patch';
 
 import { InvalidThingDescriptionException, NotFoundException } from './../../common/exceptions';
+import { NonAnonymousThingDescription } from './../../common/exceptions/non-anonymous-thing-description.exception';
 import { ThingDescription } from './../../common/interfaces/thing-description';
 import { User } from './../../common/models';
 import {
@@ -27,6 +28,7 @@ export class ThingsService {
 
   public async create(user: User, dto: ThingDescriptionDto): Promise<string> {
     this.requireValidThingDescription(dto);
+    if (dto.id) throw new NonAnonymousThingDescription();
     const urn = `urn:uuid:${randomUUID()}`;
     const now = new Date().toISOString();
     await this.thingDescriptionRepository.create({

--- a/src/common/exceptions/index.ts
+++ b/src/common/exceptions/index.ts
@@ -7,3 +7,4 @@ export * from './duplicate-email.exception';
 export * from './invalid-credentials.exception';
 export * from './invalid-thing-description.exception';
 export * from './invalid-token.exception';
+export * from './non-anonymous-thing-description.exception';

--- a/src/common/exceptions/non-anonymous-thing-description.exception.ts
+++ b/src/common/exceptions/non-anonymous-thing-description.exception.ts
@@ -1,0 +1,12 @@
+import { ProblemDetailsException } from './problem-details.exception';
+
+export class NonAnonymousThingDescription extends ProblemDetailsException {
+  public constructor() {
+    super({
+      type: '/errors/types/non-anonymous-thing-description',
+      title: 'Invalid Identified Thing Description',
+      status: 400,
+      detail: 'POST /things endpoint does not accept Thing Description with id, only anonymous Thing Description.',
+    });
+  }
+}

--- a/test/e2e/things.e2e-spec.ts
+++ b/test/e2e/things.e2e-spec.ts
@@ -41,6 +41,20 @@ describe('/things', () => {
       });
     });
 
+    it('should fail to register the Thing Description when it is not anonymous', async () => {
+      const { status, data } = await axios.post('/things', validThingDescription, {
+        headers: { Authorization: `Bearer ${defaultAccessToken}` },
+      });
+
+      expect(status).toBe(400);
+      expect(data).toMatchObject({
+        type: '/errors/types/non-anonymous-thing-description',
+        title: 'Invalid Identified Thing Description',
+        status: 400,
+        detail: 'POST /things endpoint does not accept Thing Description with id, only anonymous Thing Description.',
+      });
+    });
+
     it('should fail to register the Thing Description when it is invalid', async () => {
       const { status, data } = await axios.post('/things', invalidThingDescription, {
         headers: { Authorization: `Bearer ${defaultAccessToken}` },


### PR DESCRIPTION
When POST a valid TD with an id, Zion replies with 400 and the following error message.

```json
{
  "type": "/errors/types/non-anonymous-thing-description",
  "title": "Invalid Identified Thing Description",
  "status": 400,
  "detail": "POST /things endpoint does not accept Thing Description with id, only anonymous Thing Description."
}
```

Tests were added to enforce the expected behavior.