### PR TITLE
13 missing check on put thingsid create to prevent a different id in the body

### DIFF
--- a/src/api-reference/things/things.service.ts
+++ b/src/api-reference/things/things.service.ts
@@ -72,7 +72,7 @@ export class ThingsService {
       this.eventsService.emitUpdated({ id, ...patch });
       return true;
     } else {
-      if (!dto.id || id !== dto.id) throw new MismatchIdException();
+      if ( id !== dto.id) throw new MismatchIdException();
       await this.thingDescriptionRepository.create({
         urn: id,
         json: dto,

--- a/src/api-reference/things/things.service.ts
+++ b/src/api-reference/things/things.service.ts
@@ -3,8 +3,12 @@ import { randomUUID } from 'crypto';
 import { Injectable } from '@nestjs/common';
 import { generate as generatePatch, apply as mergePatch } from 'json-merge-patch';
 
-import { InvalidThingDescriptionException, NotFoundException } from './../../common/exceptions';
-import { NonAnonymousThingDescription } from './../../common/exceptions/non-anonymous-thing-description.exception';
+import {
+  InvalidThingDescriptionException,
+  MismatchIdException,
+  NonAnonymousThingDescription,
+  NotFoundException,
+} from './../../common/exceptions';
 import { ThingDescription } from './../../common/interfaces/thing-description';
 import { User } from './../../common/models';
 import {
@@ -68,6 +72,7 @@ export class ThingsService {
       this.eventsService.emitUpdated({ id, ...patch });
       return true;
     } else {
+      if (!dto.id || id !== dto.id) throw new MismatchIdException();
       await this.thingDescriptionRepository.create({
         urn: id,
         json: dto,

--- a/src/common/exceptions/index.ts
+++ b/src/common/exceptions/index.ts
@@ -8,3 +8,4 @@ export * from './invalid-credentials.exception';
 export * from './invalid-thing-description.exception';
 export * from './invalid-token.exception';
 export * from './non-anonymous-thing-description.exception';
+export * from './mismatch-id.exception';

--- a/src/common/exceptions/mismatch-id.exception.ts
+++ b/src/common/exceptions/mismatch-id.exception.ts
@@ -1,0 +1,12 @@
+import { ProblemDetailsException } from './problem-details.exception';
+
+export class MismatchIdException extends ProblemDetailsException {
+  public constructor() {
+    super({
+      type: '/errors/types/mismatch-id-expection',
+      title: 'Mismatch ID',
+      status: 400,
+      detail: 'The id specified in the URL does not match the id in the Thing Description body',
+    });
+  }
+}

--- a/test/e2e/things.e2e-spec.ts
+++ b/test/e2e/things.e2e-spec.ts
@@ -192,6 +192,22 @@ describe('/things', () => {
         });
       });
 
+      it('should fail to create the Thing Description if the URL id does not match the body id', async () => {
+        const id = getShortUnique();
+
+        const { status, data } = await axios.put(`/things/${id}`, validThingDescription, {
+          headers: { Authorization: `Bearer ${defaultAccessToken}` },
+        });
+
+        expect(status).toBe(400);
+        expect(data).toMatchObject({
+          type: '/errors/types/mismatch-id-expection',
+          title: 'Mismatch ID',
+          status: 400,
+          detail: 'The id specified in the URL does not match the id in the Thing Description body',
+        });
+      });
+
       it('should update the Thing Description', async () => {
         const { headers } = await axios.post('/things', validAnonymousThingDescription, {
           headers: { Authorization: `Bearer ${defaultAccessToken}` },
@@ -211,7 +227,7 @@ describe('/things', () => {
       });
 
       it('should create the Thing Description', async () => {
-        const id = getShortUnique();
+        const id = validThingDescription.id;
 
         const { status } = await axios.put(`/things/${id}`, validThingDescription, {
           headers: { Authorization: `Bearer ${defaultAccessToken}` },

--- a/test/e2e/things.e2e-spec.ts
+++ b/test/e2e/things.e2e-spec.ts
@@ -208,6 +208,50 @@ describe('/things', () => {
         });
       });
 
+      it('should fail to create the Thing Description if a anonymous Thing Description is sent', async () => {
+        const id = getShortUnique();
+
+        const { status, data } = await axios.put(`/things/${id}`, validAnonymousThingDescription, {
+          headers: { Authorization: `Bearer ${defaultAccessToken}` },
+        });
+
+        expect(status).toBe(400);
+        expect(data).toMatchObject({
+          type: '/errors/types/mismatch-id-expection',
+          title: 'Mismatch ID',
+          status: 400,
+          detail: 'The id specified in the URL does not match the id in the Thing Description body',
+        });
+      });
+
+      it('should fail to create the Thing Description if a anonymous Thing Description is sent and no id is provided in the URL', async () => {
+        const { status, data } = await axios.put(`/things/`, validAnonymousThingDescription, {
+          headers: { Authorization: `Bearer ${defaultAccessToken}` },
+        });
+
+        expect(status).toBe(400);
+        expect(data).toMatchObject({
+          type: '/errors/types/mismatch-id-expection',
+          title: 'Mismatch ID',
+          status: 400,
+          detail: 'The id specified in the URL does not match the id in the Thing Description body',
+        });
+      });
+
+      it('should fail to create the Thing Description if no id is provided in the URL', async () => {
+        const { status, data } = await axios.put(`/things/`, validThingDescription, {
+          headers: { Authorization: `Bearer ${defaultAccessToken}` },
+        });
+
+        expect(status).toBe(400);
+        expect(data).toMatchObject({
+          type: '/errors/types/mismatch-id-expection',
+          title: 'Mismatch ID',
+          status: 400,
+          detail: 'The id specified in the URL does not match the id in the Thing Description body',
+        });
+      });
+
       it('should update the Thing Description', async () => {
         const { headers } = await axios.post('/things', validAnonymousThingDescription, {
           headers: { Authorization: `Bearer ${defaultAccessToken}` },

--- a/test/e2e/things.e2e-spec.ts
+++ b/test/e2e/things.e2e-spec.ts
@@ -271,16 +271,18 @@ describe('/things', () => {
       });
 
       it('should create the Thing Description', async () => {
-        const id = validThingDescription.id;
-
-        const { status } = await axios.put(`/things/${id}`, validThingDescription, {
+        const id = `${validThingDescription.id}:${getShortUnique()}`;
+        const validThingDescriptionObject = validThingDescription;
+        validThingDescriptionObject.id = id;
+        console.log(validThingDescriptionObject.id);
+        const { status } = await axios.put(`/things/${id}`, validThingDescriptionObject, {
           headers: { Authorization: `Bearer ${defaultAccessToken}` },
         });
 
         const { data } = await axios.get(`/things/${id}`);
 
         expect(status).toBe(201);
-        expect(data).toStrictEqual(validThingDescription);
+        expect(data).toStrictEqual(validThingDescriptionObject);
       });
     });
 


### PR DESCRIPTION
When a new TD is created via the PUT /things/{id} endpoint, it checks if the id in the body matches the one in the URL. Otherwise, it throws the following exception:
```json
{
  "type": "/errors/types/mismatch-id-expection",
  "title": "Mismatch ID",
  "status": 400,
  "detail": "The id specified in the URL does not match the id in the Thing Description body"
}

```