### PR TITLE
14 update operations do not update the td id correctly

### DIFF
--- a/src/api-reference/things/things.service.ts
+++ b/src/api-reference/things/things.service.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from 'crypto';
 
 import { Injectable } from '@nestjs/common';
-import { boolean } from 'joi';
 import { generate as generatePatch, apply as mergePatch } from 'json-merge-patch';
 
 import {
@@ -12,7 +11,6 @@ import {
 } from './../../common/exceptions';
 import { ThingDescription } from './../../common/interfaces/thing-description';
 import { User } from './../../common/models';
-import { InternalThingDescription } from './../../common/models/internal-thing-description';
 import {
   deanonymizeThingDescription,
   deanonymizeThingDescriptions,

--- a/src/common/exceptions/duplicate-id.exception.ts
+++ b/src/common/exceptions/duplicate-id.exception.ts
@@ -1,0 +1,12 @@
+import { ProblemDetailsException } from './problem-details.exception';
+
+export class DuplicateIdException extends ProblemDetailsException {
+  public constructor(id: string) {
+    super({
+      type: '/errors/types/duplicate-id',
+      title: 'Duplicate Id',
+      status: 409,
+      detail: `The id ${id} is already in use by another Thing Description`,
+    });
+  }
+}

--- a/src/common/exceptions/index.ts
+++ b/src/common/exceptions/index.ts
@@ -8,3 +8,4 @@ export * from './invalid-credentials.exception';
 export * from './invalid-thing-description.exception';
 export * from './invalid-token.exception';
 export * from './non-anonymous-thing-description.exception';
+export * from './duplicate-id.exception';

--- a/test/e2e/things.e2e-spec.ts
+++ b/test/e2e/things.e2e-spec.ts
@@ -1,7 +1,6 @@
 import { INestApplication } from '@nestjs/common';
 import { AxiosInstance } from 'axios';
 
-import { ThingDescription } from './../../src/common/interfaces/thing-description';
 import { User } from './../../src/common/models';
 import { getAccessToken } from './../utils/auth';
 import { getShortUnique, getThingDescriptionIdFromHeaderLocation } from './../utils/data';

--- a/test/e2e/things.e2e-spec.ts
+++ b/test/e2e/things.e2e-spec.ts
@@ -1,6 +1,7 @@
 import { INestApplication } from '@nestjs/common';
 import { AxiosInstance } from 'axios';
 
+import { ThingDescription } from './../../src/common/interfaces/thing-description';
 import { User } from './../../src/common/models';
 import { getAccessToken } from './../utils/auth';
 import { getShortUnique, getThingDescriptionIdFromHeaderLocation } from './../utils/data';
@@ -210,6 +211,24 @@ describe('/things', () => {
         });
       });
 
+      it('should update the Thing Description id and update the URL urn', async () => {
+        const { headers } = await axios.post('/things', validAnonymousThingDescription, {
+          headers: { Authorization: `Bearer ${defaultAccessToken}` },
+        });
+        const id = `urn:dev:ops:${getShortUnique()}`;
+        const updatedThingDescription = { ...validAnonymousThingDescription, id: id };
+
+        await axios.put(headers.location, updatedThingDescription, {
+          headers: { Authorization: `Bearer ${defaultAccessToken}` },
+        });
+
+        const { status } = await axios.get(headers.location);
+        expect(status).toBe(404);
+
+        const { data } = await axios.get(`/things/${id}`);
+        expect(data).toMatchObject(updatedThingDescription);
+      });
+
       it('should create the Thing Description', async () => {
         const id = getShortUnique();
 
@@ -302,6 +321,26 @@ describe('/things', () => {
           id: getThingDescriptionIdFromHeaderLocation(headers.location),
           ...validAnonymousThingDescription,
           ...modifiedParts,
+        });
+      });
+
+      it('should update the Thing Description id and update the URL urn', async () => {
+        const { headers } = await axios.post('/things', validAnonymousThingDescription, {
+          headers: { Authorization: `Bearer ${defaultAccessToken}` },
+        });
+        const modifiedId = { id: `urn:dev:ops:${getShortUnique()}` };
+
+        await axios.patch(headers.location, modifiedId, {
+          headers: { Authorization: `Bearer ${defaultAccessToken}`, 'Content-Type': 'application/merge-patch+json' },
+        });
+
+        const { status } = await axios.get(headers.location);
+        expect(status).toBe(404);
+
+        const { data } = await axios.get(`/things/${modifiedId.id}`);
+        expect(data).toStrictEqual({
+          ...validAnonymousThingDescription,
+          ...modifiedId,
         });
       });
     });


### PR DESCRIPTION
When a TD is updated (PUT or PATCH), the `internalThingDescription` urn is updated as well. Additionally, there is an additional check to ensure that the new id is not a duplicated one. The new exception is: 
```json
{
  "type": "/errors/types/duplicate-id",
  "title": "Duplicate Id",
  "status": 409,
  "detail": "The id {id} is already in use by another Thing Description"
}
```