### PR TITLE
feat: add support for introduction via CoRE Link Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ services:
 - [ ] Standard API
   * [ ] XPath queries
   * [ ] SPARQL queries supported with an external SPARQL endpoint
-  * [ ] CoRE introduction method
+  * [x] CoRE introduction method
 - [ ] Experimental API
   * [ ] GEO spatial queries
   * [ ] User private TD collection CRUD 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ and flexible. Currently, Zion supports the following features:
 - [Introduction methods](https://w3c.github.io/wot-discovery/#introduction-mech) :
   - DNS-SD
   - Well-known URL
+  - CoRE Link Format and `/.well-known/core`
 - Standard API:
   - CRUD operations on the collection of TDs
   - JSONPath queries compliant with IETF JSONPath standard [draft 5](https://datatracker.ietf.org/doc/html/draft-ietf-jsonpath-base#section-3.5.8)

--- a/src/introduction/well-known.controller.ts
+++ b/src/introduction/well-known.controller.ts
@@ -28,4 +28,10 @@ export class WellKnownController {
     response.header('Content-length', `${size}`);
     await response.send();
   }
+
+  @Get('core')
+  @Header('Content-type', 'application/link-format')
+  public wellKnownCore() {
+    return '</wot>rt="wot.directory";ct=432';
+  }
 }

--- a/src/introduction/well-known.controller.ts
+++ b/src/introduction/well-known.controller.ts
@@ -5,9 +5,13 @@ import { FastifyReply } from 'fastify';
 import { WellKnownService } from './well-known.service';
 
 /**
- * This controller is used to expose the Thing Description document.
+ * This controller is used to handle well-known URIs.
+ *
+ * It exposes the Thing Description document via `/.well-known/wot` and
+ * implements the CoRE Link Format introduction method via `/.well-known/core`.
  *
  * @see https://w3c.github.io/wot-discovery/#introduction-well-known
+ * @see https://w3c.github.io/wot-discovery/#introduction-core-rd-sec
  */
 @ApiTags('Introduction')
 @Controller('.well-known')

--- a/test/e2e/well-known.e2e-spec.ts
+++ b/test/e2e/well-known.e2e-spec.ts
@@ -9,6 +9,10 @@ describe('/well-known', () => {
    * @see https://w3c.github.io/wot-discovery/#introduction-well-known
    */
   const SPECIFICATION_PATH = 'wot';
+  /**
+   * @see https://www.rfc-editor.org/rfc/rfc6690.html#section-7.1
+   */
+  const WELL_KNOWN_CORE_PATH = 'core';
   let axios: AxiosInstance;
   let app: INestApplication;
 
@@ -64,6 +68,26 @@ describe('/well-known', () => {
         expect(status).toBe(200);
         expect(headers['content-type']).toContain('application/td+json');
         expect(headers['content-length']).toBeDefined();
+      });
+    });
+  });
+
+  describe(`/${WELL_KNOWN_CORE_PATH}`, () => {
+    describe('GET', () => {
+      it('should answer to well-known', async () => {
+        const { status } = await axios.get(`/.well-known/${WELL_KNOWN_CORE_PATH}`);
+        expect(status).toBe(200);
+      });
+
+      /**
+       * @see https://w3c.github.io/wot-discovery/#introduction-core-rd-sec
+       */
+      it('should follow the specification', async () => {
+        const { status, headers, data } = await axios.get(`/.well-known/${WELL_KNOWN_CORE_PATH}`);
+
+        expect(status).toBe(200);
+        expect(data).toBe('</wot>rt="wot.directory";ct=432');
+        expect(headers['content-type']).toContain('application/link-format');
       });
     });
   });


### PR DESCRIPTION
Hi everyone!

This PR adds support for the CoRE Link Format introduction method (see https://w3c.github.io/wot-discovery/#introduction-core-rd-sec), exposing the `/.well-known/wot` resource as a single link under `/.well-known/core` (see [RFC 6690](https://www.rfc-editor.org/rfc/rfc6690.html)).

I integrated the route into the `WellKnownController` controller and generalized the documentation a bit, covering both `/.well-known/wot` and `/.well-known/core`. Let me know if there is anything that should be changed :)

(Using this introduction method for HTTP does not make as much sense as it does for CoAP, since HTTP does not support multicast. However, it is a feature currently at risk in the Discovery specification, therefore I thought it would be nice if there was one (additional) implementation 🙂)

(Partially?) resolves #20.