### PR TITLE
feat: implement security bootstrapping

### DIFF
--- a/src/auth/auth.guard.ts
+++ b/src/auth/auth.guard.ts
@@ -7,6 +7,7 @@ import { InvalidTokenException } from './../common/exceptions';
 export class AuthGuard extends NestAuthGuard('jwt') {
   public handleRequest<TUser = any>(err: any, user: any, info: any, context: any, status?: any): TUser {
     if (err || !user) {
+      context.getResponse().headers({ 'WWW-Authenticate': `Bearer realm=things` });
       throw new InvalidTokenException();
     }
     return user;

--- a/test/e2e/things.e2e-spec.ts
+++ b/test/e2e/things.e2e-spec.ts
@@ -32,13 +32,15 @@ describe('/things', () => {
 
   describe('POST', () => {
     it('should fail to register the Thing Description when the user is not authenticated', async () => {
-      const { status, data } = await axios.post('/things', validAnonymousThingDescription);
+      const { status, data, headers } = await axios.post('/things', validAnonymousThingDescription);
       expect(status).toBe(401);
       expect(data).toMatchObject({
         type: '/errors/types/invalid-token',
         title: 'Invalid Token',
         status: 401,
       });
+
+      expect(headers).toHaveProperty('www-authenticate', 'Bearer realm=things');
     });
 
     it('should fail to register the Thing Description when it is not anonymous', async () => {


### PR DESCRIPTION
This PR adds security bootstrapping (via a `WWW-Authenticate` header) to the `AuthGuard` used by Zion and adjusts the existing tests accordingly.

Resolves #26.