### PR TITLE
fix: adjust CoRE Link Format link

### DIFF
--- a/src/introduction/well-known.controller.ts
+++ b/src/introduction/well-known.controller.ts
@@ -36,6 +36,6 @@ export class WellKnownController {
   @Get('core')
   @Header('Content-type', 'application/link-format')
   public wellKnownCore() {
-    return '</wot>rt="wot.directory";ct=432';
+    return '</.well-known/wot>;rt="wot.directory";ct=432';
   }
 }

--- a/test/e2e/well-known.e2e-spec.ts
+++ b/test/e2e/well-known.e2e-spec.ts
@@ -86,7 +86,7 @@ describe('/well-known', () => {
         const { status, headers, data } = await axios.get(`/.well-known/${WELL_KNOWN_CORE_PATH}`);
 
         expect(status).toBe(200);
-        expect(data).toBe('</wot>rt="wot.directory";ct=432');
+        expect(data).toBe('</.well-known/wot>;rt="wot.directory";ct=432');
         expect(headers['content-type']).toContain('application/link-format');
       });
     });


### PR DESCRIPTION
Hi again :)

Testing the CoRE Link Format route with another implementation, I noticed that I made two small mistakes preventing the feature from actually working 😅 This PR now includes the correct path `/.well-known/wot` in the exposed link and adds a missing semicolon that prevented consumers from parsing the link correctly. Sorry for not getting this right the first time :/