### PR TITLE
Update @context URLs, add response contentType workaround

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@nestjs/platform-fastify": "^9.3.9",
         "@nestjs/serve-static": "^3.0.1",
         "@nestjs/swagger": "^6.2.1",
-        "@node-wot/td-tools": "^0.8.0",
+        "@node-wot/td-tools": "^0.8.6",
         "@vaimee/jsonpath-to-sqljsonpath": "^1.0.2",
         "ajv": "^8.11.0",
         "ajv-formats-draft2019": "^1.6.1",
@@ -81,7 +81,7 @@
         "ts-node": "^10.0.0",
         "tsconfig-paths": "^3.10.1",
         "typescript": "^4.3.5",
-        "wot-thing-description-types": "^1.1.0-09-February-2022"
+        "wot-thing-description-types": "^1.1.0-13-October-2022"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2593,15 +2593,18 @@
       }
     },
     "node_modules/@node-wot/td-tools": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@node-wot/td-tools/-/td-tools-0.8.0.tgz",
-      "integrity": "sha512-YS9QPjT+NxGCJ2huSy3HX3b/5z0qJxUmymA7Yb9xwsOQrSI4LsBhfn4MrAX1WRLL5i4VY1YkexOMzUe84Mkm2A==",
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@node-wot/td-tools/-/td-tools-0.8.6.tgz",
+      "integrity": "sha512-3lFSGrBujKkPVD0Kn45/+FApwlyKDAZAbRskk5boe3hpiyxnIAhBp4EBiMa/DmzKL7KZnYSvUVnsXFexFtniiQ==",
       "dependencies": {
+        "ajv": "^8.11.0",
+        "debug": "^4.3.4",
         "is-absolute-url": "3.0.3",
+        "json-placeholder-replacer": "^1.0.35",
         "url-toolkit": "2.1.6",
-        "wot-thing-description-types": "^1.1.0-09-February-2022",
-        "wot-thing-model-types": "^1.1.0-3-February-2022",
-        "wot-typescript-definitions": "0.8.0-SNAPSHOT.22"
+        "wot-thing-description-types": "1.1.0-23-March-2023",
+        "wot-thing-model-types": "1.1.0-23-March-2023",
+        "wot-typescript-definitions": "0.8.0-SNAPSHOT.25"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -10233,6 +10236,15 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
+    "node_modules/json-placeholder-replacer": {
+      "version": "1.0.35",
+      "resolved": "https://registry.npmjs.org/json-placeholder-replacer/-/json-placeholder-replacer-1.0.35.tgz",
+      "integrity": "sha512-edlSWqcFVUpKPshaIcJfXpQ8eu0//gk8iU6XHWkCZIp5QEp4hoCFR7uk+LrIzhLTSqmBQ9VBs+EYK8pvWGEpRg==",
+      "bin": {
+        "jpr": "dist/index.js",
+        "json-placeholder-replacer": "dist/index.js"
+      }
+    },
     "node_modules/json-schema-resolver": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/json-schema-resolver/-/json-schema-resolver-1.3.0.tgz",
@@ -15582,19 +15594,22 @@
       "dev": true
     },
     "node_modules/wot-thing-description-types": {
-      "version": "1.1.0-09-February-2022",
-      "resolved": "https://registry.npmjs.org/wot-thing-description-types/-/wot-thing-description-types-1.1.0-09-February-2022.tgz",
-      "integrity": "sha512-XQ83iwPm5Y4i68VSu30k+ROHMgvSIdAAOx4BS+nOWwnW/v1oKsDAaeaIPiJu0ReLk7HvSd+ewaRgaL6aqCNnOQ=="
+      "version": "1.1.0-23-March-2023",
+      "resolved": "https://registry.npmjs.org/wot-thing-description-types/-/wot-thing-description-types-1.1.0-23-March-2023.tgz",
+      "integrity": "sha512-uS0ngJGTKsWLU0NpECGpfmzpae0nTwFwawwpEY5PVA71bUjTdvw3YCMTK1WG+7/1CYxKwXw72JtlsFJ6DApp9w=="
     },
     "node_modules/wot-thing-model-types": {
-      "version": "1.1.0-3-February-2022",
-      "resolved": "https://registry.npmjs.org/wot-thing-model-types/-/wot-thing-model-types-1.1.0-3-February-2022.tgz",
-      "integrity": "sha512-IYetSr4Z7DmXESMg2OKDyIPTRwGSciIMuJBPyABNptNHodbwcMHx/48GO0kx6TpsDy9gBYkGO1SFXvt1/NZoMw=="
+      "version": "1.1.0-23-March-2023",
+      "resolved": "https://registry.npmjs.org/wot-thing-model-types/-/wot-thing-model-types-1.1.0-23-March-2023.tgz",
+      "integrity": "sha512-Ty8NrbE8kImKkvwktc5oh0K4L1iDg1vxnR6NmUaAEMKZPfLmCbYdOL+IOcd82gLPiyT8+aaS/E6owH92UjVcIA=="
     },
     "node_modules/wot-typescript-definitions": {
-      "version": "0.8.0-SNAPSHOT.22",
-      "resolved": "https://registry.npmjs.org/wot-typescript-definitions/-/wot-typescript-definitions-0.8.0-SNAPSHOT.22.tgz",
-      "integrity": "sha512-1K57EfbZkLderX5/hTVGkBjmTAwm/bZNdp1aywgKK1Tov5Ml2oAJRyhr4i3q5+75gZfSjU30Sxu0/WyOirAFRw=="
+      "version": "0.8.0-SNAPSHOT.25",
+      "resolved": "https://registry.npmjs.org/wot-typescript-definitions/-/wot-typescript-definitions-0.8.0-SNAPSHOT.25.tgz",
+      "integrity": "sha512-mZadvXCWzf77xHLMTwM9O8bokLhQbyqW07q+x2/kD1AT2wwkPxU9+Gj3psmTaSX8Pvev6orVY3ICuU1g2ukvLA==",
+      "dependencies": {
+        "wot-thing-description-types": "1.1.0-23-March-2023"
+      }
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -17616,15 +17631,18 @@
       }
     },
     "@node-wot/td-tools": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@node-wot/td-tools/-/td-tools-0.8.0.tgz",
-      "integrity": "sha512-YS9QPjT+NxGCJ2huSy3HX3b/5z0qJxUmymA7Yb9xwsOQrSI4LsBhfn4MrAX1WRLL5i4VY1YkexOMzUe84Mkm2A==",
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@node-wot/td-tools/-/td-tools-0.8.6.tgz",
+      "integrity": "sha512-3lFSGrBujKkPVD0Kn45/+FApwlyKDAZAbRskk5boe3hpiyxnIAhBp4EBiMa/DmzKL7KZnYSvUVnsXFexFtniiQ==",
       "requires": {
+        "ajv": "^8.11.0",
+        "debug": "^4.3.4",
         "is-absolute-url": "3.0.3",
+        "json-placeholder-replacer": "^1.0.35",
         "url-toolkit": "2.1.6",
-        "wot-thing-description-types": "^1.1.0-09-February-2022",
-        "wot-thing-model-types": "^1.1.0-3-February-2022",
-        "wot-typescript-definitions": "0.8.0-SNAPSHOT.22"
+        "wot-thing-description-types": "1.1.0-23-March-2023",
+        "wot-thing-model-types": "1.1.0-23-March-2023",
+        "wot-typescript-definitions": "0.8.0-SNAPSHOT.25"
       }
     },
     "@nodelib/fs.scandir": {
@@ -23501,6 +23519,11 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
+    "json-placeholder-replacer": {
+      "version": "1.0.35",
+      "resolved": "https://registry.npmjs.org/json-placeholder-replacer/-/json-placeholder-replacer-1.0.35.tgz",
+      "integrity": "sha512-edlSWqcFVUpKPshaIcJfXpQ8eu0//gk8iU6XHWkCZIp5QEp4hoCFR7uk+LrIzhLTSqmBQ9VBs+EYK8pvWGEpRg=="
+    },
     "json-schema-resolver": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/json-schema-resolver/-/json-schema-resolver-1.3.0.tgz",
@@ -27390,19 +27413,22 @@
       "dev": true
     },
     "wot-thing-description-types": {
-      "version": "1.1.0-09-February-2022",
-      "resolved": "https://registry.npmjs.org/wot-thing-description-types/-/wot-thing-description-types-1.1.0-09-February-2022.tgz",
-      "integrity": "sha512-XQ83iwPm5Y4i68VSu30k+ROHMgvSIdAAOx4BS+nOWwnW/v1oKsDAaeaIPiJu0ReLk7HvSd+ewaRgaL6aqCNnOQ=="
+      "version": "1.1.0-23-March-2023",
+      "resolved": "https://registry.npmjs.org/wot-thing-description-types/-/wot-thing-description-types-1.1.0-23-March-2023.tgz",
+      "integrity": "sha512-uS0ngJGTKsWLU0NpECGpfmzpae0nTwFwawwpEY5PVA71bUjTdvw3YCMTK1WG+7/1CYxKwXw72JtlsFJ6DApp9w=="
     },
     "wot-thing-model-types": {
-      "version": "1.1.0-3-February-2022",
-      "resolved": "https://registry.npmjs.org/wot-thing-model-types/-/wot-thing-model-types-1.1.0-3-February-2022.tgz",
-      "integrity": "sha512-IYetSr4Z7DmXESMg2OKDyIPTRwGSciIMuJBPyABNptNHodbwcMHx/48GO0kx6TpsDy9gBYkGO1SFXvt1/NZoMw=="
+      "version": "1.1.0-23-March-2023",
+      "resolved": "https://registry.npmjs.org/wot-thing-model-types/-/wot-thing-model-types-1.1.0-23-March-2023.tgz",
+      "integrity": "sha512-Ty8NrbE8kImKkvwktc5oh0K4L1iDg1vxnR6NmUaAEMKZPfLmCbYdOL+IOcd82gLPiyT8+aaS/E6owH92UjVcIA=="
     },
     "wot-typescript-definitions": {
-      "version": "0.8.0-SNAPSHOT.22",
-      "resolved": "https://registry.npmjs.org/wot-typescript-definitions/-/wot-typescript-definitions-0.8.0-SNAPSHOT.22.tgz",
-      "integrity": "sha512-1K57EfbZkLderX5/hTVGkBjmTAwm/bZNdp1aywgKK1Tov5Ml2oAJRyhr4i3q5+75gZfSjU30Sxu0/WyOirAFRw=="
+      "version": "0.8.0-SNAPSHOT.25",
+      "resolved": "https://registry.npmjs.org/wot-typescript-definitions/-/wot-typescript-definitions-0.8.0-SNAPSHOT.25.tgz",
+      "integrity": "sha512-mZadvXCWzf77xHLMTwM9O8bokLhQbyqW07q+x2/kD1AT2wwkPxU9+Gj3psmTaSX8Pvev6orVY3ICuU1g2ukvLA==",
+      "requires": {
+        "wot-thing-description-types": "1.1.0-23-March-2023"
+      }
     },
     "wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@nestjs/platform-fastify": "^9.3.9",
     "@nestjs/serve-static": "^3.0.1",
     "@nestjs/swagger": "^6.2.1",
-    "@node-wot/td-tools": "^0.8.0",
+    "@node-wot/td-tools": "^0.8.6",
     "@vaimee/jsonpath-to-sqljsonpath": "^1.0.2",
     "ajv": "^8.11.0",
     "ajv-formats-draft2019": "^1.6.1",
@@ -137,6 +137,6 @@
     "ts-node": "^10.0.0",
     "tsconfig-paths": "^3.10.1",
     "typescript": "^4.3.5",
-    "wot-thing-description-types": "^1.1.0-09-February-2022"
+    "wot-thing-description-types": "^1.1.0-13-October-2022"
   }
 }

--- a/src/common/utils/thing-description-converter.ts
+++ b/src/common/utils/thing-description-converter.ts
@@ -1,4 +1,9 @@
-import { ThingContext, ThingContextW3CUri } from 'wot-thing-description-types';
+import {
+  ThingContext,
+  ThingContextTdUriTemp,
+  ThingContextTdUriV1,
+  ThingContextTdUriV11,
+} from 'wot-thing-description-types';
 
 import { ENRICHED_TD_CONTEXT } from '../constants';
 import { EnrichedThingDescription, ThingDescription } from '../interfaces/thing-description';
@@ -44,6 +49,8 @@ export function enrichThingDescription(internalThingDescription: InternalThingDe
     },
   };
 }
+
+type ThingContextW3CUri = ThingContextTdUriV1 | ThingContextTdUriTemp | ThingContextTdUriV11;
 
 type ThingContextArray = Exclude<ThingContext, [] | ThingContextW3CUri>;
 function enrichThingDescriptionContext(context: ThingContext): ThingContext {

--- a/src/introduction/td-builder.service.ts
+++ b/src/introduction/td-builder.service.ts
@@ -22,7 +22,9 @@ export class ThingDescriptionBuilderService {
       },
     };
 
-    const td = (await builder.getPartialTDs(model, options))[0];
+    // FIXME: Get rid of this workaround.
+    const clonedModel = JSON.parse(JSON.stringify(model));
+    const td = (await builder.getPartialTDs(clonedModel, options))[0];
     this.built = td as ThingDescription;
     // TODO: chose the right security schema using configs
     this.built.securityDefinitions = { nosec: { scheme: 'nosec' } };

--- a/src/introduction/td-builder.service.ts
+++ b/src/introduction/td-builder.service.ts
@@ -27,6 +27,39 @@ export class ThingDescriptionBuilderService {
     // TODO: chose the right security schema using configs
     this.built.securityDefinitions = { nosec: { scheme: 'nosec' } };
     this.built.security = 'nosec';
+
+    // TODO: Make inclusion of fix configurable
+    this.insertResponseContentType();
+
     return this.built;
+  }
+
+  /**
+   * Applies the fix described in section 7.3.2.4 of the Discovery specification to make the
+   * TDD's Thing Description compatible with the TD specification and Consumers performing
+   * validation by including a <code>contentType</code> that is missing from the TM
+   * describing the directory's API.
+   *
+   * TODO: Update URL once the change has been included in the published specification.
+   * @see https://w3c.github.io/wot-discovery/#directory-api-spec
+   */
+  private insertResponseContentType(): void {
+    const actions = this.built?.actions;
+
+    if (actions == null) {
+      return;
+    }
+
+    const actionsToFix = ['createThing', 'createAnonymousThing', 'updateThing', 'partiallyUpdateThing', 'deleteThing'];
+
+    for (const key of actionsToFix) {
+      const invalidResponse = actions[key]?.forms[0].response;
+
+      if (invalidResponse == null) {
+        continue;
+      }
+
+      invalidResponse['contentType'] = 'application/x-empty';
+    }
   }
 }

--- a/src/introduction/tdd.tm.json
+++ b/src/introduction/tdd.tm.json
@@ -10,6 +10,20 @@
     "title": "Zion",
     "description": "A scalable Thing Description Directory",
     "base": "{{DIRECTORY_BASE_URL}}",
+    "tm:optional": [
+        "/actions/createThing",
+        "/actions/createAnonymousThing",
+        "/actions/retrieveThing",
+        "/actions/updateThing",
+        "/actions/partiallyUpdateThing",
+        "/actions/deleteThing",
+        "/actions/searchJSONPath",
+        "/actions/searchXPath",
+        "/actions/searchSPARQL",
+        "/events/thingCreated",
+        "/events/thingUpdated",
+        "/events/thingDeleted"
+    ],
     "properties": {
         "things": {
             "description": "Retrieve all Thing Descriptions",
@@ -272,7 +286,7 @@
             ]
         },
         "searchJSONPath": {
-            "description": "JSONPath syntactic search",
+            "description": "JSONPath syntactic search.",
             "uriVariables": {
                 "query": {
                     "title": "A valid JSONPath expression",
@@ -305,7 +319,7 @@
             ]
         },
         "searchXPath": {
-            "description": "XPath syntactic search",
+            "description": "XPath syntactic search.",
             "uriVariables": {
                 "query": {
                     "title": "A valid XPath expression",

--- a/src/introduction/tdd.tm.json
+++ b/src/introduction/tdd.tm.json
@@ -1,7 +1,7 @@
 {
     "@context": [
-        "http://www.w3.org/ns/td",
-        "https://w3c.github.io/wot-discovery/context/discovery-context.jsonld"
+        "https://www.w3.org/2022/wot/td/v1.1",
+        "https://www.w3.org/2022/wot/discovery"
     ],
     "@type": [
         "tm:ThingModel",


### PR DESCRIPTION
This PR updates the @context URLs included in the directory's TM/TD in anticipation of https://github.com/w3c/wot-discovery/pull/471 and applies the workaround added in https://github.com/w3c/wot-discovery/pull/469 to the `ThingDescriptionBuilderService` by inserting `application/x-empty` as a `contentType` for `response` objects where the field absent.

Combined, these changes result in a TD for the Directory that [passes validation](https://www.jsonschemavalidator.net/s/0hdr6hBo) against the latest [JSON Schema document](https://github.com/w3c/wot-thing-description/blob/main/validation/td-json-schema-validation.json) provided in the TD repository :) 