### PR TITLE
fix(docker-compose): override local defined DB port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - POSTGRES_DB=${ZION_DB_TYPE}
     container_name: 'zion-postgres-dev'
     ports:
-      - '${DB_PORT}:5432'
+      - '${ZION_DB_PORT}:5432'
   zion:
     build: .
     depends_on:
@@ -20,7 +20,7 @@ services:
     environment:
       - ZION_NODE_ENV
       - ZION_SERVER_PORT
-      - ZION_DB_HOST=database
+      - ZION_DB_HOST=host.docker.internal
       - ZION_DB_PORT
       - ZION_DB_USER
       - ZION_DB_PASSWORD


### PR DESCRIPTION
Probably inside the docker-compose does not really make sense to use another port rather than the default. Mainly this PR fixes #55 so that users can start the stack right away, if they really want to personalize it they can always define their own stack. 